### PR TITLE
Improve power bomb explosion code

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -45,6 +45,7 @@ Enemy_MakesDebrisWhenHit equ 08082FECh
 Enemy_CreateDebris equ 08083090h
 Enemy_CreatePlasmaDebris equ 080831C4h
 
+FixedPointMultiply equ 08000B10h
 Divide equ 080A3468h
 memcpy equ 080A4EF0h
 memset equ 080A4F50h

--- a/src/main.s
+++ b/src/main.s
@@ -46,6 +46,7 @@ StartingLocation equ 087FF228h
 .if OPTIMIZE
 .notice "Applying optimization patches..."
 .include "src/optimization/item-check.s"
+.include "src/optimization/power-bomb-explosion.s"
 .elseif RANDOMIZER
 .include "src/optimization/item-check.s"
 .endif

--- a/src/optimization/power-bomb-explosion.s
+++ b/src/optimization/power-bomb-explosion.s
@@ -3,7 +3,7 @@
 
 .org 08068130h
 .area 28h
-    ; In vanilla, the game mutiplies by 0.95 using floating-point arithmetic.
+    ; In vanilla, the game multiplies by 0.95 using floating-point arithmetic.
     ; Instead, we can used fixed-point multiplication with 243/256, which
     ; equals 0.949219 for an error of 0.000781 (0.0822%)
     mov     r1, 243

--- a/src/optimization/power-bomb-explosion.s
+++ b/src/optimization/power-bomb-explosion.s
@@ -1,0 +1,16 @@
+; Converts floating-point arithmetic to fixed-point for calculating the size
+; of a power bomb explosion. Saves an average of 10050 cycles per frame.
+
+.org 08068130h
+.area 28h
+    ; In vanilla, the game mutiplies by 0.95 using floating-point arithmetic.
+    ; Instead, we can used fixed-point multiplication with 243/256, which
+    ; equals 0.949219 for an error of 0.000781 (0.0822%)
+    mov     r1, 243
+    bl      FixedPointMultiply
+    mov     r8, r0
+    mov     r0, r6
+    mov     r1, 243
+    bl      FixedPointMultiply
+    b       08068158h
+.endarea


### PR DESCRIPTION
This changes the power bomb explosion code to use much faster fixed-point multiplication instead of floating-point multiplication. The relative error is very small (0.0822%) so gameplay should not be affected.

Decomp code for reference: https://github.com/YohannDR/mf/blob/6aa7bce7e1a66bec248478d08adf81034cff0b0b/src/power_bomb_explosion.c#L54