### PR TITLE
room-fixes: don't initially spawn hornoads in hornoad housing

### DIFF
--- a/inc/structs.inc
+++ b/inc/structs.inc
@@ -532,6 +532,12 @@ Sector6Levels equ 083C7C38h
 
 SpritesetList equ 0879ADD8h
 NullSpriteset equ 083BF884h
+.sym off
+Spriteset_SpriteY equ 00h
+Spriteset_SpriteX equ 01h
+Spriteset_SpriteProp equ 02h
+Spriteset_SpriteSize equ 03h
+.sym on
 
 AreaScrolls equ 0879BB08h
 .sym off

--- a/src/nonlinear/room-edits.s
+++ b/src/nonlinear/room-edits.s
@@ -288,6 +288,16 @@
     .db     Event_GoMode
 .endarea
 
+; Sector 1 - Hornoad Housing
+; have hornoads spawn by x forming them
+.org readptr(Sector1Levels + 2Eh * LevelMeta_Size + LevelMeta_Spriteset0)
+.area 15
+    .skip 6
+    .db 07h, 08h, 16h
+    .skip 3
+    .db 07h, 0Ah, 16h
+.endarea
+
 ; Sector 1 - Sciser Playground
 ; fix screen scroll when entering room from Charge Core Access
 .defineregion readptr(Sector1Scrolls + 07h * 4), ScrollList_HeaderSize + Scroll_Size * 1
@@ -331,14 +341,14 @@
 
 ; Sector 2 - Zoro Zig-Zag
 ; moves zoro coocoons to prevent blocking morph ball tunnels
-.org readptr(Sector2Levels + 09h * LevelMeta_Size + LevelMeta_Spriteset1) + (3 * 7)
+.org readptr(Sector2Levels + 09h * LevelMeta_Size + LevelMeta_Spriteset1) + (7 * Spriteset_SpriteSize)
 .area 9
     .db 25h, 17h, 14h
     .db 2Ah, 1Bh, 14h
     .db 32h, 1Bh, 14h
 .endarea
 
-.org readptr(Sector2Levels + 09h * LevelMeta_Size + LevelMeta_Spriteset2) + (3 * 0Bh)
+.org readptr(Sector2Levels + 09h * LevelMeta_Size + LevelMeta_Spriteset2) + (0Bh * Spriteset_SpriteSize)
 .area 9
     .db 26h, 17h, 14h
     .db 2Ah, 1Bh, 14h
@@ -801,6 +811,14 @@
     .db     0FFh, 0FFh
     .db     ScrollExtend_None
     .db     0FFh
+.endarea
+
+; Sector 4 - Pump Control Save Room
+; fix entering the room for the first time from morph tunnel
+; this should only be an issue for entrance rando
+.org Sector4Doors + 045h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db 0E0h
 .endarea
 
 ; Sector 4 - Cheddar Bay


### PR DESCRIPTION
* Sector 1: Don't initially spawn hornoads in hornoad housing. fixes #84
* Sector 4: spawn samus farther left when entering from morph tunnel. fixes #82
