### PR TITLE
Fix Inconsistent Wave Beam Damage

### DIFF
--- a/inc/structs.inc
+++ b/inc/structs.inc
@@ -214,7 +214,7 @@ SamusState_ArmCannonDirection equ 07h
 SamusState_SecondaryWeaponSelect equ 08h
 SamusState_ProjectileType equ 09h
 SamusState_ProjectileCooldown equ 0Ah
-SamusState_SoloWaveDirection equ 0Bh    ; non-vanilla
+SamusState_Unk01 equ 0Bh
 SamusState_ChargeCounter equ 0Ch
 SamusState_DiagonalAim equ 0Dh
 SamusState_ArmSwing equ 0Eh

--- a/src/nonlinear/beam-stacking.s
+++ b/src/nonlinear/beam-stacking.s
@@ -706,20 +706,8 @@
     ; fire two projectiles with wave beam
     lsr     r0, r2, BeamUpgrade_WaveBeam + 1
     bcc     @@spawnProjectiles
-    ldr     r2, =SamusState
-    ldrb    r0, [r2, SamusState_SoloWaveDirection]
-    sub     r1, r0, #1
-    cmp     r1, #1
-    bhi     @@normalizeSoloWave
-    mov     r1, #3
-    eor     r0, r1
-    b       @@setWaveOptions
-@@normalizeSoloWave:
-    mov     r0, #1
-@@setWaveOptions:
-    strb    r0, [r2, SamusState_SoloWaveDirection]
-    mov     r6, r0
-    mov     r7, r0
+    mov     r6, #2
+    mov     r7, #1
     b       @@spawnProjectiles
 @@spawnPureCharge:
     ; spawn center charge projectile


### PR DESCRIPTION
Change uncharged Wave Beam (without Wide Beam) to fire two projectiles. Use the existing logic from the Charge Beam Wave shot.

SamusState_SoloWaveDirection is no longer used in the ASM code, it did not have any values stored there in Vanilla, so update constant appropriately

closes #48 