### PR TITLE
sector 2: Fix regression where doors were linking to incorrect rooms

### DIFF
--- a/src/nonlinear/room-edits.s
+++ b/src/nonlinear/room-edits.s
@@ -524,12 +524,22 @@
     .db     DoorType_LockableHatch
 .endarea
 
+.org Sector2Doors + 60h * DoorEntry_Size + DoorEntry_Destination
+.area 1
+    .db     67h
+.endarea
+
 .org Sector2Doors + 65h * DoorEntry_Size + DoorEntry_Type
 .area 6
     .db     DoorType_NoHatch
     .db     0Eh
     .db     5, 6
     .db     0Ch, 0Dh
+.endarea
+
+.org Sector2Doors + 67h * DoorEntry_Size + DoorEntry_Destination
+.area 1
+    .db     60h
 .endarea
 
 ; Sector 2 - Zazabi Access


### PR DESCRIPTION
Fix #129
When the transition was added from Dessgeega Dormitory to Shadow Moses Island, some doors were left pointing at their original location which resulted in loading incorrect rooms.