### PR TITLE
Remove S5 Geron Checkpoint Geron if using RANDOMIZER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@
 * Changed: Security Shaft East: Repair the door to Kago Blockade.
 * Changed: Ripper Road: Replace lv0 door to Arctic Containment with an open hatch.
 * Changed: Crow's Nest: Repair the door to Arctic Containment into a lv3 security door.
-* Changed: Geron Checkpoint: Randomizer only, remove Geron, even when Power Bomb Data has been acquired.
+* Changed: Geron Checkpoint: (Randomizer only) Remove Geron, even when Power Bomb Data has been acquired.
 #### Sector 6
 * Changed: Zozoro Wine Cellar: (Optional) Change reforming bomb block in front of expansion tank to a never reforming bomb block to prevent being trapped by running out of power bombs.
 * Changed: Big Shell 1: (Optional) Remove the crumble block into the long morph tunnel to prevent softlocks without power bombs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 * Changed: Security Shaft East: Repair the door to Kago Blockade.
 * Changed: Ripper Road: Replace lv0 door to Arctic Containment with an open hatch.
 * Changed: Crow's Nest: Repair the door to Arctic Containment into a lv3 security door.
+* Changed: Geron Checkpoint: Randomizer only, remove Geron, even when Power Bomb Data has been acquired.
 #### Sector 6
 * Changed: Zozoro Wine Cellar: (Optional) Change reforming bomb block in front of expansion tank to a never reforming bomb block to prevent being trapped by running out of power bombs.
 * Changed: Big Shell 1: (Optional) Remove the crumble block into the long morph tunnel to prevent softlocks without power bombs.

--- a/src/nonlinear/room-edits.s
+++ b/src/nonlinear/room-edits.s
@@ -1070,19 +1070,6 @@
     .dw     @S5_ArcticContainment_Clipdata
 .endarea
 
-.if RANDOMIZER
-; Sector 5 - Geron Checkpoint
-; Remove power bomb geron spriteset
-.defineregion readptr(Sector5Levels + 08h * LevelMeta_Size + LevelMeta_Spriteset2), 15h
-.org Sector5Levels + 08h * LevelMeta_Size + LevelMeta_Spriteset2Event
-.area LevelMeta_Spriteset2Id - LevelMeta_Spriteset1Id
-    .db     0
-    .skip   2
-    .dw     NullSpriteset
-    .db     0
-.endarea
-.endif
-
 .org Sector5Doors + 15h * DoorEntry_Size + DoorEntry_Type
 .area 1
     .db     DoorType_LockableHatch
@@ -1133,6 +1120,19 @@
 
 .org Sector5Doors + 46h * DoorEntry_Size
 .fill DoorEntry_Size, 0FFh
+
+.if RANDOMIZER
+; Sector 5 - Geron Checkpoint
+; Remove power bomb geron spriteset
+.defineregion readptr(Sector5Levels + 08h * LevelMeta_Size + LevelMeta_Spriteset2), 15h
+.org Sector5Levels + 08h * LevelMeta_Size + LevelMeta_Spriteset2Event
+.area LevelMeta_Spriteset2Id - LevelMeta_Spriteset1Id
+    .db     0
+    .skip   2
+    .dw     NullSpriteset
+    .db     0
+.endarea
+.endif
 
 ; Sector 5 - Frozen Tower
 ; remove event-based transitions

--- a/src/nonlinear/room-edits.s
+++ b/src/nonlinear/room-edits.s
@@ -1070,6 +1070,19 @@
     .dw     @S5_ArcticContainment_Clipdata
 .endarea
 
+.if RANDOMIZER
+; Sector 5 - Geron Checkpoint
+; Remove power bomb geron spriteset
+.defineregion readptr(Sector5Levels + 08h * LevelMeta_Size + LevelMeta_Spriteset2), 15h
+.org Sector5Levels + 08h * LevelMeta_Size + LevelMeta_Spriteset2Event
+.area LevelMeta_Spriteset2Id - LevelMeta_Spriteset1Id
+    .db     0
+    .skip   2
+    .dw     NullSpriteset
+    .db     0
+.endarea
+.endif
+
 .org Sector5Doors + 15h * DoorEntry_Size + DoorEntry_Type
 .area 1
     .db     DoorType_LockableHatch

--- a/src/nonlinear/room-states.s
+++ b/src/nonlinear/room-states.s
@@ -256,7 +256,7 @@
     bx      lr
 @@case_42:
     ; downloaded power bombs
-    ; spritesets: S5-08, S5-09, S5-18
+    ; spritesets: S5-08 (non-Randomized), S5-09, S5-18
     ; room states: S5-15 => S5-16, S5-27 => S5-28
     ldrb    r0, [r2, PermanentUpgrades_ExplosiveUpgrades]
     lsl     r0, #1Fh - ExplosiveUpgrade_PowerBombs


### PR DESCRIPTION
Removes the Spriteset that contains the Geron in this room (triggered by picking up PB Data)

Fixes #110 