### PR TITLE
Fix two escape related issues:

### DIFF
--- a/inc/structs.inc
+++ b/inc/structs.inc
@@ -502,7 +502,13 @@ CreditsLine_Size equ 24h
 .sym on
 
 AreaLevels equ 0879B8BCh
+NullBg equ 083BF850h
 .sym off
+LevelMeta_Tileset equ 00h
+LevelMeta_Bg0Properties equ 01h
+LevelMeta_Bg1Properties equ 02h
+LevelMeta_Bg2Properties equ 03h
+LevelMeta_Bg3Properties equ 04h
 LevelMeta_Bg0 equ 08h
 LevelMeta_Bg1 equ 0Ch
 LevelMeta_Bg2 equ 10h

--- a/src/nonlinear/room-edits.s
+++ b/src/nonlinear/room-edits.s
@@ -1011,6 +1011,12 @@
 .incbin "data/rooms/S5-03-Clip.rlebg"
 .endautoregion
 
+; Remove Nightmare flying around by removing BG0
+.org Sector5Levels + 03h * LevelMeta_Size + LevelMeta_Bg0Properties
+    .db     0
+.org Sector5Levels + 03h * LevelMeta_Size + LevelMeta_Bg0
+    .dw     NullBg
+
 .org Sector5Levels + 03h * LevelMeta_Size + LevelMeta_Bg1
 .area 0Ch
     .dw     @S5_NightmareTrainingGrounds_Bg1

--- a/src/nonlinear/story-flags.s
+++ b/src/nonlinear/story-flags.s
@@ -202,9 +202,11 @@
     .pool
 .endarea
 
-; Override event based water lowering. Vanilla code checks if the Event is > 1Fh
-; If so it will lower the water, even if the Pump Station hasn't been triggered.
-; The escape sequence sets Event to 67h
+; Override event based water lowering. Vanilla code, presumably in some failsafe
+; or development function checks if the Event is > 1Fh in any room.
+; If so it will trigger lowing the water, even if the Pump Station hasn't been triggered.
+; The escape sequence sets Event to 67h. Change the code to always branch to the 
+; code location used when Event <= 1Fh
 .org 08063754h
 .area 0Ah, 0
     b       80637FEh  

--- a/src/nonlinear/story-flags.s
+++ b/src/nonlinear/story-flags.s
@@ -204,7 +204,7 @@
 
 ; Override event based water lowering. Vanilla code, presumably in some failsafe
 ; or development function checks if the Event is > 1Fh in any room.
-; If so it will trigger lowing the water, even if the Pump Station hasn't been triggered.
+; If so it will trigger lowering the water, even if the Pump Station hasn't been triggered.
 ; The escape sequence sets Event to 67h. Change the code to always branch to the 
 ; code location used when Event <= 1Fh
 .org 08063754h

--- a/src/nonlinear/story-flags.s
+++ b/src/nonlinear/story-flags.s
@@ -202,6 +202,14 @@
     .pool
 .endarea
 
+; Override event based water lowering. Vanilla code checks if the Event is > 1Fh
+; If so it will lower the water, even if the Pump Station hasn't been triggered.
+; The escape sequence sets Event to 67h
+.org 08063754h
+.area 0Ah, 0
+    b       80637FEh  
+.endarea
+
 .org 08063956h
 .area 52h, 0
     ; update water lowered flag


### PR DESCRIPTION
1. S4 Water will lower as soon as entering a room that can have lowered water.
2. Nightmare was flying around in Training Grounds

fixes #121 