### PR TITLE
S2-Cathedral: move zoro to opposite wall

### DIFF
--- a/src/nonlinear/room-edits.s
+++ b/src/nonlinear/room-edits.s
@@ -377,7 +377,7 @@
 .endarea
 .endif
 
-; Sector 2 - Central Shaft
+; Sector 2 - Cathedral
 ; make door to reo room functional
 ; remove hatch to ripper roost
 ; move zoro out of the way of ripper roost
@@ -411,24 +411,28 @@
     .dw     @S2_CentralShaft_KihunterSpriteset
 .endarea
 
-.org readptr(Sector2Levels + 0Dh * LevelMeta_Size + LevelMeta_Spriteset0) + 1 * 03h
-.area 09h
-    .db     1Bh, 05h, 24h
-    .skip 3
+.org readptr(Sector2Levels + 0Dh * LevelMeta_Size + LevelMeta_Spriteset0) + (1 * Spriteset_SpriteSize)
+.area 03h
+    .db     17h, 05h, 24h
+.endarea
+
+.org readptr(Sector2Levels + 0Dh * LevelMeta_Size + LevelMeta_Spriteset0) + (3 * Spriteset_SpriteSize)
+.area 03h
     .db     2Bh, 03h, 24h
 .endarea
 
-.org readptr(Sector2Levels + 2Eh * LevelMeta_Size + LevelMeta_Spriteset0) + 1 * 03h
+
+.org readptr(Sector2Levels + 2Eh * LevelMeta_Size + LevelMeta_Spriteset0) + (1 * Spriteset_SpriteSize)
 .area 03h
-    .db     1Bh, 05h, 14h
+    .db     17h, 05h, 24h
 .endarea
 
-.org readptr(Sector2Levels + 2Eh * LevelMeta_Size + LevelMeta_Spriteset1) + 2 * 03h
+.org readptr(Sector2Levels + 2Eh * LevelMeta_Size + LevelMeta_Spriteset1) + (2 * Spriteset_SpriteSize)
 .area 03h
-    .db     1Bh, 05h, 14h
+    .db     17h, 05h, 24h
 .endarea
 
-.org readptr(Sector2Levels + 2Eh * LevelMeta_Size + LevelMeta_Spriteset1) + 6 * 03h
+.org readptr(Sector2Levels + 2Eh * LevelMeta_Size + LevelMeta_Spriteset1) + (6 * Spriteset_SpriteSize)
 .area 03h
     .db     2Ch, 03h, 17h
 .endarea


### PR DESCRIPTION
Fixes #197 

![grafik](https://github.com/user-attachments/assets/e7b26eb7-95a0-4fa3-b9d0-7d872d1668d8)

After moving him to the opposite wall, I found that that severely hinders climbing up the room. So I moved him to the top.

Haven't refactored the room edit into its own file because it's rather messy and I just wanted to have the fix out.