### PR TITLE
fix: file import order

### DIFF
--- a/src/main.s
+++ b/src/main.s
@@ -118,14 +118,13 @@ DataFreeSpaceEnd equ DataFreeSpace + DataFreeSpaceLen
 .include "src/qol/skip-ending.s"
 .include "src/qol/skip-intro.s"
 .include "src/qol/unhidden-breakable-tiles.s"
-
 .if UNHIDDEN_MAP
 .include "src/qol/unhidden-map.s"
 .endif
 .if UNHIDDEN_MAP_DOORS
 .include "src/qol/unhidden-map-doors.s"
 .endif
-
+.include "src/qol/unhidden-pillars.s"
 .endif
 
 ; Physics patches

--- a/src/qol/unhidden-breakable-tiles.s
+++ b/src/qol/unhidden-breakable-tiles.s
@@ -329,5 +329,3 @@ if (r0 >= ClipdataTile_VerticalBombChain1 and
     .pool
 .endfunc
 .endautoregion
-
-.include "src/qol/unhidden-pillars.s"


### PR DESCRIPTION
Fixes a regression where importing unhidden-pillars before unhidden-maps causes major patch file differences with unhidden-maps. These differences can include pointers to stored data which would differ after applying an unhidden map patch, causing the patcher to patch data which is no longer accurate once https://github.com/MetroidAdvRandomizerSystem/mars-patcher-py/pull/154 has merged.

Screenshot shows file differences beyond what is intentional.
53e9cd4 is the current `main` HEAD, 9f48e44 is `main` before #272 was merged
![image](https://github.com/user-attachments/assets/3d6dd345-6a98-428a-be71-6834fb741e84)
