### PR TITLE
Fix weapon gfx reload code to ensure clearing of ReloadWeaponGfxFlag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fixed: Game crash caused by alignment of Minor item data within the ROM.
+- Fixed: Ensure that the flag for reloading weapon gfx is cleared after reloading graphics.
 
 ## 0.8.1 - 2025-08-26
 - Fixed: Custom Title Screen text could be dismissed accidentally when pressing `A` or `START` during the fade-in of "Press Start" and Copyright info.

--- a/src/nonlinear/common.s
+++ b/src/nonlinear/common.s
@@ -319,18 +319,18 @@
 .endfunc
 
 .func CheckReloadWeaponGfx
-    push    { lr }
-    ldr     r1, =ReloadWeaponGfxFlag
-    ldrb    r0, [r1]
+    push    { r4, lr }
+    ldr     r4, =ReloadWeaponGfxFlag
+    ldrb    r0, [r4]
     cmp     r0, #0
     beq     @@return
 
     bl      LoadBeamGfx
     bl      LoadMissileGfx
     mov     r0, #0
-    strb    r0, [r1]
+    strb    r0, [r4]
 @@return:
-    pop     { pc }
+    pop     { r4, pc }
     .pool
 .endfunc
 .endautoregion


### PR DESCRIPTION
I used a register which is not guaranteed to be the same after calling a function. ):