### PR TITLE
Fix: File import order with Instant Unmorph

### DIFF
--- a/src/main.s
+++ b/src/main.s
@@ -134,16 +134,16 @@ DataFreeSpaceEnd equ DataFreeSpace + DataFreeSpaceLen
 
 .endif
 
-; Instant Unmorph Patch
-.if INSTANT_UNMORPH
-.include "src/physics/instant-morph.s"
-.endif
-
 ; Accessibility patches
 ; Patches which make the game more acccessible to people.
 .if ACCESSIBILITY
 .include "src/a11y/accessible-enemy-gfx.s"
 .include "src/a11y/accessible-flashing.s"
+.endif
+
+; Instant Unmorph Patch
+.if INSTANT_UNMORPH
+.include "src/physics/instant-morph.s"
 .endif
 
 ; Non-linearity patches


### PR DESCRIPTION
Fixes a regression where importing Instant Unmorph before Accessibility, causing autoregions to move to very different places and thus making the python patcher fail on reading some data.

See #275 for a similar issue

Before 
<img width="275" height="174" alt="image" src="https://github.com/user-attachments/assets/fd957fdb-1c08-433f-8292-edef141edc67" />

After 
<img width="445" height="122" alt="image" src="https://github.com/user-attachments/assets/6d93f3be-a791-4244-9db8-5edc4b2153b5" />
