### PR TITLE
fix credits never switching to final completion screen due to misaligned data

### DIFF
--- a/src/randomizer/credits.s
+++ b/src/randomizer/credits.s
@@ -81,7 +81,7 @@
     ldrh    r0, [r2]
     add     r0, r1
     strh    r0, [r2]
-@@skipForPause:    
+@@skipForPause:
     b       080A22D8h
     .pool
 .endarea
@@ -111,7 +111,8 @@
     .dw     CreditsEndDelay
 .endarea
 
-.autoregion
+.autoregion DataFreeSpace, DataFreeSpaceEnd
+    .align 2
 CreditsEndDelay:
     .dh     512
 CreditsScrollSpeed:


### PR DESCRIPTION
Data misalignment surfaced after changes to build system where nonlinear/randomizer flags were removed to always be included.