### PR TITLE
Remove Bombless-PBs option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased - 2026-??-??
 
+- Removed: The compilation flag for Bombless PBs. This is now always included.
+
 ## 0.10.0 - 2026-01-03
 - Fixed: Energy values over 2099 now correctly render in-game.
 - Changed: Maximum Energy has been limited to 9999.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ else
 	AS := armips
 endif
 
-OPTIONALS := bombless_pbs
 OPTIONALS += missiles_without_mains
 OPTIONALS += unhidden_map
 OPTIONALS += unhidden_map_doors

--- a/src/main.s
+++ b/src/main.s
@@ -17,9 +17,6 @@
 .ifndef ACCESSIBILITY
 .definelabel ACCESSIBILITY, 0
 .endif
-.ifndef BOMBLESS_PBS
-.definelabel BOMBLESS_PBS, 0
-.endif
 .ifndef MISSILES_WITHOUT_MAINS
 .definelabel MISSILES_WITHOUT_MAINS, 0
 .endif
@@ -164,6 +161,7 @@ DataFreeSpaceEnd equ DataFreeSpace + DataFreeSpaceLen
 .include "src/physics/single-walljump.s"
 .include "src/nonlinear/split-suits.s"
 .include "src/nonlinear/story-flags.s"
+.include "src/nonlinear/bombless-pbs.s"
 ; End non-linearity patches
 
 .if NERF_GERON_WEAKNESS
@@ -172,9 +170,6 @@ DataFreeSpaceEnd equ DataFreeSpace + DataFreeSpaceLen
 
 .if !DEBUG
 .include "src/nonlinear/item-select.s"
-.endif
-.if BOMBLESS_PBS
-.include "src/nonlinear/bombless-pbs.s"
 .endif
 
 ; Randomizer patches

--- a/src/nonlinear/item-select.s
+++ b/src/nonlinear/item-select.s
@@ -140,11 +140,7 @@
 @@init_bombs:
     ldr     r0, =PermanentUpgrades
     ldrb    r2, [r0, PermanentUpgrades_ExplosiveUpgrades]
-.if BOMBLESS_PBS
     mov     r0, #(1 << ExplosiveUpgrade_Bombs) | (1 << ExplosiveUpgrade_PowerBombs)
-.else
-    mov     r0, #(1 << ExplosiveUpgrade_Bombs)
-.endif
     tst     r0, r2
     beq     @@init_suits
     ldr     r0, =#0B0EAh


### PR DESCRIPTION
Helps with nonlinearity.
If someone for some reason wants the ability to not be able to use pbs before bombs, then what they need is progressive bombs, not this.
Part of #346 