### PR TITLE
Split Screw and Speedbooster vulnerabilities

### DIFF
--- a/inc/enums.inc
+++ b/inc/enums.inc
@@ -199,6 +199,7 @@ SamusPose_Unmorphing equ 0Fh
 SamusPose_MorphBallMidAir equ 10h
 SamusPose_WallJumping equ 16h
 SamusPose_ScrewAttacking equ 1Eh
+SamusPose_Shinesparking equ 24h
 SamusPose_Dying equ 3Eh
 SamusPose_FrozenRequest equ 0FBh
 
@@ -287,8 +288,9 @@ SpriteWeakness_BeamOrBombs equ 1
 SpriteWeakness_SuperMissiles equ 2
 SpriteWeakness_Missiles equ 3
 SpriteWeakness_PowerBombs equ 4
-SpriteWeakness_SpeedboosterOrScrew equ 5
+SpriteWeakness_ScrewAttack equ 5     ; In vanilla this is Speedbooster or Screw Attack, but we changed this here.
 SpriteWeakness_Freezable equ 6
+SpriteWeakness_Speedbooster equ 7
 
 Projectile_NormalBeam equ 0
 Projectile_ChargeBeam equ 1

--- a/inc/macros.inc
+++ b/inc/macros.inc
@@ -60,6 +60,9 @@
 ; read pointer from source file
 .expfunc readptr(pos), readu32("metroid4.gba", pos & 0xFFFFFF)
 
+; read byte from source file
+.expfunc read_byte_at_current_pos(), readbyte("metroid4.gba", org() & 0xFFFFFF)
+
 ; create OAM frame for the nav lock sprite based on the security level
 .macro nav_lock_oam_frame, level
     .dh 4
@@ -123,4 +126,18 @@ label:
     .align 4
 label:
     .skip 4
+.endmacro
+
+; Goes through all sprites starting from start_value, to end_value (including), and if that sprite contains
+; a screw attack weakness, gets adjusted to also get a speed booster weakness.
+; stat_address is the base address for the sprite stats. Should be either `SpriteStats` or `SecondarySpriteStats`
+.macro adjust_speed_weakness_of_sprites, start_value, end_value, stat_address
+    .if start_value < (SpriteStats ? 0CEh : 081h) && start_value <= end_value
+        .org stat_address + (start_value * SpriteStats_Size) + SpriteStats_Weaknesses
+        .definelabel @@weakness, read_byte_at_current_pos()
+        .if @@weakness & (1 << SpriteWeakness_ScrewAttack)
+            .db @@weakness + (1 << SpriteWeakness_Speedbooster)
+        .endif
+        adjust_speed_weakness_of_sprites (start_value+1), end_value, stat_address
+    .endif
 .endmacro

--- a/inc/macros.inc
+++ b/inc/macros.inc
@@ -60,7 +60,7 @@
 ; read pointer from source file
 .expfunc readptr(pos), readu32("metroid4.gba", pos & 0xFFFFFF)
 
-; read byte from source file
+; read byte at the current position from source file
 .expfunc read_byte_at_current_pos(), readbyte("metroid4.gba", org() & 0xFFFFFF)
 
 ; create OAM frame for the nav lock sprite based on the security level
@@ -131,6 +131,7 @@ label:
 ; Goes through all sprites starting from start_value, to end_value (including), and if that sprite contains
 ; a screw attack weakness, gets adjusted to also get a speed booster weakness.
 ; stat_address is the base address for the sprite stats. Should be either `SpriteStats` or `SecondarySpriteStats`
+; This macro should only ever be called in steps of 128 (decimal), as otherwise armips will see it as an infinite loop and error.
 .macro adjust_speed_weakness_of_sprites, start_value, end_value, stat_address
     .if start_value < (stat_address == SpriteStats ? 0CEh : 081h) && start_value <= end_value
         .org stat_address + (start_value * SpriteStats_Size) + SpriteStats_Weaknesses

--- a/inc/macros.inc
+++ b/inc/macros.inc
@@ -132,11 +132,11 @@ label:
 ; a screw attack weakness, gets adjusted to also get a speed booster weakness.
 ; stat_address is the base address for the sprite stats. Should be either `SpriteStats` or `SecondarySpriteStats`
 .macro adjust_speed_weakness_of_sprites, start_value, end_value, stat_address
-    .if start_value < (SpriteStats ? 0CEh : 081h) && start_value <= end_value
+    .if start_value < (stat_address == SpriteStats ? 0CEh : 081h) && start_value <= end_value
         .org stat_address + (start_value * SpriteStats_Size) + SpriteStats_Weaknesses
         .definelabel @@weakness, read_byte_at_current_pos()
         .if @@weakness & (1 << SpriteWeakness_ScrewAttack)
-            .db @@weakness + (1 << SpriteWeakness_Speedbooster)
+            .db @@weakness | (1 << SpriteWeakness_Speedbooster)
         .endif
         adjust_speed_weakness_of_sprites (start_value+1), end_value, stat_address
     .endif

--- a/inc/macros.inc
+++ b/inc/macros.inc
@@ -134,7 +134,7 @@ label:
 ; This macro should only ever be called in steps of 128 (decimal), as otherwise armips will see it as an infinite loop and error.
 .macro adjust_speed_weakness_of_sprites, start_value, end_value, stat_address
     .if start_value < (stat_address == SpriteStats ? 0CEh : 081h) && start_value <= end_value
-        .org stat_address + (start_value * SpriteStats_Size) + SpriteStats_Weaknesses
+        .org stat_address + (start_value * (stat_address == SpriteStats ? SpriteStats_Size : SecondarySpriteStats_Size)) + SpriteStats_Weaknesses
         .definelabel @@weakness, read_byte_at_current_pos()
         .if @@weakness & (1 << SpriteWeakness_ScrewAttack)
             .db @@weakness | (1 << SpriteWeakness_Speedbooster)

--- a/inc/structs.inc
+++ b/inc/structs.inc
@@ -171,6 +171,7 @@ Sprite_Work5 equ 36h
 .sym on
 
 SpriteStats equ 082E4D4Ch
+SecondarySpriteStats equ 082E589Eh
 .sym off
 SpriteStats_Health equ 00h
 SpriteStats_Damage equ 02h
@@ -223,6 +224,7 @@ SamusStateBackup equ 03001270h
 SamusState_Unk00 equ 00h
 SamusState_Pose equ 01h
 SamusState_ForcedMovement equ 03h
+SamusState_SpeedboostingCounter equ 06h
 SamusState_ArmCannonDirection equ 07h
 SamusState_SecondaryWeaponSelect equ 08h
 SamusState_ProjectileType equ 09h

--- a/inc/structs.inc
+++ b/inc/structs.inc
@@ -172,6 +172,7 @@ Sprite_Work5 equ 36h
 
 SpriteStats equ 082E4D4Ch
 SecondarySpriteStats equ 082E589Eh
+SecondarySpriteStats_Size equ 08h
 .sym off
 SpriteStats_Health equ 00h
 SpriteStats_Damage equ 02h

--- a/src/main.s
+++ b/src/main.s
@@ -136,6 +136,7 @@ DataFreeSpaceEnd equ DataFreeSpace + DataFreeSpaceLen
 .notice "Applying non-linearity patches..."
 .include "src/nonlinear/common.s"
 .include "src/nonlinear/hud-edits.s"
+.include "src/nonlinear/unique_speedbooster_weakness.s"
 .include "src/nonlinear/beam-stacking.s"
 .include "src/nonlinear/bosses.s"
 .include "src/nonlinear/data-rooms.s"

--- a/src/nonlinear/unique_speedbooster_weakness.s
+++ b/src/nonlinear/unique_speedbooster_weakness.s
@@ -45,7 +45,7 @@
     mov     r0, #0
 
 @@return:
-    mov     r1, SpriteWeakness_ScrewAttack
+    mov     r1, (1 << SpriteWeakness_ScrewAttack)
     pop     { pc }
 .endfunc
 .pool

--- a/src/nonlinear/unique_speedbooster_weakness.s
+++ b/src/nonlinear/unique_speedbooster_weakness.s
@@ -1,0 +1,68 @@
+
+; Hijack ProjectileContactDamageHitSprite to properly handle speedbooster vs screw attack weakness
+
+.autoregion
+.align 2
+.func @ScrewSpeedWeaknessHijack
+    ; r0 contains the sprite weaknesses of the sprite
+    ; r0 also contains the return value on whether the condition succeeded or failed
+    ; r1 contains SpriteWeakness_ScrewAttack as a return value
+
+    ; The condition is true if:
+    ; (r0 & weakness_screw != 0) and (samus.pose == screw)
+    ; or (r0 & weakness_speed != 0) and (samus.pose == speed or samus.speedcounter != 0)
+
+    ; Check speed. 
+    push    { lr }
+    mov     r1, (1 << SpriteWeakness_Speedbooster)
+    and     r1, r0
+    cmp     r1, #0
+    beq     @@check_screw       ; Check that sprite is weak to speed...
+    ldr     r1, =SamusState
+    ldrb    r2, [r1, SamusState_Pose]
+    cmp     r2, #SamusPose_Shinesparking
+    beq     @@condition_true    ; ...and that we're either in shinesparking...
+    ldrb    r2, [r1, SamusState_SpeedboostingCounter]
+    cmp     r2, #0              ; ...or that we're currently speedboosting.
+    bne     @@condition_true
+
+    ; Check Screw
+@@check_screw:
+    mov     r1, (1 << SpriteWeakness_ScrewAttack)
+    and     r1, r0
+    cmp     r1, #0              
+    beq     @@condition_fail    ; If the speed check failed, check that the sprite is weak to Screw... 
+    ldr     r1, =SamusState
+    ldrb    r2, [r1, SamusState_Pose]
+    cmp     r2, #SamusPose_ScrewAttacking   
+    bne     @@condition_fail    ; ...and that we're currently screw attacking.
+
+@@condition_true:
+    mov     r0, #1
+    b       @@return
+
+@@condition_fail:
+    mov     r0, #0
+
+@@return:
+    mov     r1, SpriteWeakness_ScrewAttack
+    pop     { pc }
+.endfunc
+.pool
+.endautoregion
+
+.org 080834c0h   ; In ProjectileContactDamageHitSprite
+.area 8
+    bl      @ScrewSpeedWeaknessHijack
+    mov     r9, r1
+    cmp     r0, #0
+.endarea
+
+
+; Change all the enemy data to properly differentiate between screw and speed weakness
+; Primaries
+adjust_speed_weakness_of_sprites 0, 127, SpriteStats
+adjust_speed_weakness_of_sprites 128, 256, SpriteStats
+; Secondaries
+adjust_speed_weakness_of_sprites 0, 127, SecondarySpriteStats
+adjust_speed_weakness_of_sprites 128, 256, SecondarySpriteStats


### PR DESCRIPTION
Currently doesn't change any end-user facing behaviour. I want to enable that for gerons in a later pr (will likely refactor #367 for it)
I did however test a moto on the change, en-/disabling screw weakness/speed weakness works as expected.

EDIT: Fixed:
In addition, somehow recharge stations got corrupted and i have no clue why, would appreciate help figuring that out.
<https://github.com/user-attachments/assets/d31de02c-9d83-4146-9a07-e988096198fd>
