### PR TITLE
Fix: Doors from cathedral to cathedral save access not being marked as open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - Changed: The hatch graphics have been changed to be more accessible to color blind people.
 - Fixed: HUD no longer occassionally disappears after saving the animals.
 
+### Room Adjustments
+
+#### Sector 2
+- Fixed: The door in Cathedral that leads to Cathedral Save Access accidentally having the wrong door type.
+
 ## 0.11.0 - 2026-01-17
 - Fixed: Adjusted stop-enemy clipdata in Main Deck Operations Deck (S0-0D) to prevent a visual glitch when destroying the maintenance hallway cover.
 - Removed: The optimization compilation flag was removed and is now always forced.

--- a/src/nonlinear/room-edits/sector-2/room-0D-2E.s
+++ b/src/nonlinear/room-edits/sector-2/room-0D-2E.s
@@ -111,7 +111,12 @@
     .db     DoorType_LockableHatch
 .endarea
 
-.org Sector2Doors + 6Eh * DoorEntry_Size + DoorEntry_Type
+.org Sector2Doors + 1Dh * DoorEntry_Size + DoorEntry_Type
+.area 1
+    .db     DoorType_OpenHatch
+.endarea
+
+.org Sector2Doors + 69h * DoorEntry_Size + DoorEntry_Type
 .area 1
     .db     DoorType_OpenHatch
 .endarea


### PR DESCRIPTION
I forgot that it's the amount of "lockable hatches" present in the room that determines whether the clipdata will work correctly.

Also not sure why in the past door `0x6E` was tried to change to begin with? It's really strange because:
1. that's the door in *puyo palace* that goes to cathedral
2. in vanilla that is already an open hatch. so the lines actually did nothing...