### PR TITLE
Fix: permanently locked doors animating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased - 2026-??-??
 - Fixed: HUD no longer occassionally disappears after saving the animals.
+- Fixed: Permanently locked hatches will no longer animate after certain events as if they can be opened.
 
 ## 0.11.0 - 2026-01-17
 - Fixed: Adjusted stop-enemy clipdata in Main Deck Operations Deck (S0-0D) to prevent a visual glitch when destroying the maintenance hallway cover.

--- a/src/randomizer/hatch-fixes.s
+++ b/src/randomizer/hatch-fixes.s
@@ -166,3 +166,11 @@
 .area 32
     .incbin "data/nav-cutscene-gray-door.bin"
 .endarea
+
+; Early return from the DMA transfer responsible for changing the locked hatches' animated palette
+; Done at the end of UpdateHatchFlashingAnimation
+.org 08065BFCh
+.area 4
+    pop { r0 }
+    bx r0
+.endarea


### PR DESCRIPTION
I'm not quite sure if this is the best approach to fix it, or if this breaks anything else. I quickly double checked boss doors too and they seemed fine.

in decomp its this part: https://github.com/metroidret/mf/blob/35f6d719ea47eb94586f2c12aede6b700f261a94/asm/disasm_0x080645c4.s#L2715 . As it's not been decompiled yet, i looked the ghidra output for some reference, but that seems a bit broken, as the first check for that dma transfer is `CurrentNavigationRoom == MainDeckRoom0`. And stabilizers are not navigation rooms. 

Probably would be a tiny bit faster for cycles if i'd stub out the whole comparisons out, but this seemed slightly easier.

Fixes #381 
