### PR TITLE
Fix: Remove event based transition in puyo palace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased - 2026-03-??
 
+## 0.12.1 - 2026-02-??
+
+- Fixed: The lower left door in Puyo Palace leading to the wrong version of Cathedral.
+
 ## 0.12.0 - 2026-02-20
 - Changed: The hatch graphics have been changed to be more accessible to color blind people.
 - Fixed: HUD no longer occassionally disappears after saving the animals.

--- a/src/nonlinear/room-edits.s
+++ b/src/nonlinear/room-edits.s
@@ -59,6 +59,7 @@
 .include "src/nonlinear/room-edits/sector-2/room-14-22.s"
 .include "src/nonlinear/room-edits/sector-2/room-1B.s"
 .include "src/nonlinear/room-edits/sector-2/room-20-and-23.s"
+.include "src/nonlinear/room-edits/sector-2/room-2F.s"
 .include "src/nonlinear/room-edits/sector-2/room-32.s"
 .include "src/nonlinear/room-edits/sector-2/room-36.s"
 .include "src/nonlinear/room-edits/sector-2/room-39.s"

--- a/src/nonlinear/room-edits/sector-2/room-2F.s
+++ b/src/nonlinear/room-edits/sector-2/room-2F.s
@@ -1,0 +1,7 @@
+; Puyo Palace
+
+; Change lower door to not be an event based door anymore
+.org Sector2Doors + 6Eh * DoorEntry_Size + DoorEntry_Type
+.area 1
+    .db     DoorType_OpenHatch
+.endarea


### PR DESCRIPTION
Fixes a regression from #382 

Before this change:
<img width="452" height="427" alt="grafik" src="https://github.com/user-attachments/assets/b19d848c-3548-478b-8e75-12eb36861ca1" />

After this change
<img width="452" height="427" alt="grafik" src="https://github.com/user-attachments/assets/08c32545-b00d-40a2-8a1b-59d4d6f4d780" />
