### PR TITLE
fix a graphical glitch that can occur after saving the animals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## 0.12.1 - 2026-02-26
 - Fixed: The lower left door in Puyo Palace leading to the wrong version of Cathedral.
+- Fixed: HUD no longer disappears after saving the animals (again).
 
 ## 0.12.0 - 2026-02-20
 - Changed: The hatch graphics have been changed to be more accessible to color blind people.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Unreleased - 2026-03-??
 - Fixed: Low-Health alarm now plays correctly when using the alternative Health Display.
+- Fixed: HUD no longer disappears after saving the animals (again).
 
 ## 0.12.1 - 2026-02-26
 - Fixed: The lower left door in Puyo Palace leading to the wrong version of Cathedral.
-- Fixed: HUD no longer disappears after saving the animals (again).
 
 ## 0.12.0 - 2026-02-20
 - Changed: The hatch graphics have been changed to be more accessible to color blind people.

--- a/src/consistency/animals.s
+++ b/src/consistency/animals.s
@@ -2,12 +2,14 @@
 
 .org 0803964Eh
 .area 08039656h - 0803964Eh, 00
+    b   08039656h ; skip to end of area
 ; This section removes a conditional branch of MiscPadAfterInteraction
 ;   which prevents movement during the animals exiting the enclosure sequence.
 .endarea
 
 .org 0804D6B0h
 .area 0804D6C2h - 0804D6B0h, 00
+    b   0804D6C2h ; skip to end of area
 ; This section removes setting Samus' pose to "Unlocking the habitations Deck"
 ;   (0x3Bh) in DachoraWaitingForBaby which prevents movement during the animals
 ;   run-away sequence.

--- a/src/consistency/animals.s
+++ b/src/consistency/animals.s
@@ -12,3 +12,10 @@
 ;   (0x3Bh) in DachoraWaitingForBaby which prevents movement during the animals
 ;   run-away sequence.
 .endarea
+
+.org 0804D9C2h
+.area 0804D9CCh - 0804D9C2h, 00
+    b   0804D9CCh ; skip to end of area
+; This section removes incrementing Samus' current animation frame while the
+;   Baby Dachora is running to the right.
+.endarea


### PR DESCRIPTION
[Reported in discord](https://discord.com/channels/914291389293027329/1491222685487861854)

Second attempt at fixing the HUD and other sprite data in VRAM from being erroneously cleared.
Biospark found another function that was a likely culprit where the Baby Dachora was adjusting Samus's current animation frame, normally that would be fine when the player is locked into position, but it is not fine when the player has free movement during the "cutscene"