### PR TITLE
fix: offworld item graphics no longer show as an empty tank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## Unreleased - 2026-05-??
+## Unreleased - 2026-06-??
+- Fixed: Offworld item graphics no longer appear as an Empty Tank
 
 ## 0.12.2 - 2026-04-17
 - Fixed: Low-Health alarm now plays correctly when using the alternative Health Display.

--- a/src/randomizer/tank-majors.s
+++ b/src/randomizer/tank-majors.s
@@ -53,7 +53,7 @@
     add     r0, #53h
     strh    r0, [r2]
 @@load_tank_vram:
-    cmp     r4, #UpgradeSprite_InfantMetroid
+    cmp     r4, #UpgradeSprite_ArchipelagoMonochrome
     bls     @@load_tiles
     mov     r4, #UpgradeSprite_Empty
 @@load_tiles:
@@ -160,7 +160,7 @@
     lsl     r0, #7
     add     r1, r0
     ldrb    r0, [r4, RoomTanks_Sprite]
-    cmp     r0, #UpgradeSprite_InfantMetroid
+    cmp     r0, #UpgradeSprite_ArchipelagoMonochrome
     bls     @@load_tiles
     mov     r0, #UpgradeSprite_Empty
 @@load_tiles:
@@ -316,7 +316,7 @@
     .db     0   ; shiny missile tank
     .db     0   ; shiny power bomb tank
     .db     1   ; infant metroid
-    .db     1   ; samus head 
+    .db     1   ; samus head
     .db     0   ; walljump boots
     .db     1   ; randovania
     .db     1   ; archipelago color


### PR DESCRIPTION
Reported by StalledStorm,

Archipelago Graphics were showing as empty item tanks. The check for item display checked for Infant Metroid enum value as the "end of the list", when we added new item graphics we extended the enum, but did not update the "end of list" check in code.