### PR TITLE
Remove RNG from zazabi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Changed: The time it takes for the Gadora to open its eye is now always set to be the fastest time.
 - Changed: Added an option to change how many times each Gadora shoots before being vulnerable. If not provided, it will fall back to vanilla behaviour.
+- Changed: Added an option to tweak each Gadora how often it shoots projectiles before being vulnerable. If not provided, it will fall back to vanilla behaviour.
+- Changed: Added an option to adjust how long Zazabi additionally jumps/crawls for.
 
 ## 0.12.3 - 2026-06-16
 - Fixed: Offworld item graphics no longer appear as an Empty Tank

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Changed: The time it takes for the Gadora to open its eye is now always set to be the fastest time.
 - Changed: Added an option to change how many times each Gadora shoots before being vulnerable. If not provided, it will fall back to vanilla behaviour.
 - Changed: Added an option to tweak each Gadora how often it shoots projectiles before being vulnerable. If not provided, it will fall back to vanilla behaviour.
-- Changed: Added an option to adjust how long Zazabi additionally jumps/crawls for.
+- Changed: Added an option to adjust how many additional jumps Zazabi does in rounds 1 to 3, and how long it crawls for in round 4. If not provided, it will fall back to vanilla behaviour.
 
 ## 0.12.3 - 2026-06-16
 - Fixed: Offworld item graphics no longer appear as an Empty Tank

--- a/src/consistency/zazabi.s
+++ b/src/consistency/zazabi.s
@@ -1,0 +1,90 @@
+; Removes relevant RNG of Zazabi:
+; Each phase can have its own number assigned by the patcher on how much to offset the base result by. 
+; For phase 1 to 3, this number denotes how many additional jumps Zazabi does where it cannot be hit.
+; Thus the calculation on how many extra jumps to do ends up as: (CurrentPhase-1) + ProvidedNumber
+; For phase 4, the number denotes how many additional frames to crawl more. The final calculation ends up as: 60 + ProvidedNumber
+
+
+; In ZazabiCrawling, Hijack where it tries to adjust work3 for amount of jumps in first 3 phases
+.org 08045A6Ah 
+.area 8
+    bl @ZazabiCrawlingHijack
+.endarea
+
+; In ZazabiCrawlingInit, hijack where it tries to adjust work1 on how long to crawl for in last phase
+.org 08045980h
+.area 8
+    bl @ZazabiCrawlingInitHijack
+.endarea
+
+
+@ZazabiMagicNumber equ 0FFh
+
+.org ZazabiTablePointer
+.area 04h
+    .dw     ZazabiLookupTable
+.endarea
+
+.autoregion
+.align 2
+ZazabiLookupTable:
+.fill 4, @ZazabiMagicNumber   ; 4 distinct phases
+
+.func @ZazabiCrawlingHijack
+; r0 is value of work3 (after doing gSpriteRandomNumber/4), r1 points to work3, r2 is gSubSpriteData1.health, r4 is gCurrentSprite
+; At the end of the function, r0 has to be the new value work3 and r1 has to point to work3
+
+; We do essentially 5 - (gSubSpriteData1.health / 20), and use that as an offset to our table.
+; The subsprite health goes from 40 to 100, in steps of 20.
+    push    { r1 }
+    mov     r4, r0
+    mov     r0, r2
+    mov     r1, #20
+    bl DivideUnsigned
+    mov     r1, #5
+    sub     r0, r1, r0
+    ldr     r1, =ZazabiLookupTable
+    ldrb    r0, [r1, r0]
+    pop     { r1 }      ; restore r1 to point to work3
+    cmp     r0, #@ZazabiMagicNumber
+    bne     @@ApplyOffsets
+    mov     r0, r4      ; If offset was magic number, restore the original random number
+
+@@ApplyOffsets:
+    ; Vanilla functionality on each phase having one more jump
+    cmp     r2, #60
+    bne     @@Check80HealthCase
+    add     r0, #2
+    b       @@Exit
+
+@@Check80HealthCase:
+    cmp     r2, #80
+    bne     @@Exit
+    add     r0, #1
+
+@@Exit:
+    bl      08045A7Eh    ; return back to original function which stores r0 back into work3 (r1). 
+
+.pool
+.endfunc
+
+.func @ZazabiCrawlingInitHijack
+; r0 is the value of work1 (after doing gSpriteRandomNumber*8), r3 is gCurrentSprite
+; At the end of the function, r0 has to be the value of work1 and r1 has to point to work1
+    mov     r1, r0      ; temp store the random value in r1
+    ldr     r0, =ZazabiLookupTable
+    ldrb    r0, [r0, #3]
+    cmp     r0, @ZazabiMagicNumber
+    bne     @@Exit
+    mov     r0, r1      ; offset was magic number, so restore it back to random number
+
+@@Exit:
+    ; Vanilla functionality of the minimum being 60 frames
+    add     r0, #60
+    mov     r1, r3
+    add     r1, Sprite_Work1
+    bl      0804599Ah   ; return back to original function which stores r0 back into work1 (r1)
+
+.pool
+.endfunc
+.endautoregion

--- a/src/consistency/zazabi.s
+++ b/src/consistency/zazabi.s
@@ -18,7 +18,7 @@
 .endarea
 
 
-@ZazabiMagicNumber equ 0FFh
+@ZazabiDefaultAdjustmentNumber equ 0FFh
 
 .org ZazabiTablePointer
 .area 04h
@@ -28,7 +28,7 @@
 .autoregion
 .align 2
 ZazabiLookupTable:
-.fill 4, @ZazabiMagicNumber   ; 4 distinct phases
+.fill 4, @ZazabiDefaultAdjustmentNumber   ; 4 distinct phases
 
 .func @ZazabiCrawlingHijack
 ; r0 is value of work3 (after doing gSpriteRandomNumber/4), r1 points to work3, r2 is gSubSpriteData1.health, r4 is gCurrentSprite
@@ -36,17 +36,17 @@ ZazabiLookupTable:
 
 ; We do essentially 5 - (gSubSpriteData1.health / 20), and use that as an offset to our table.
 ; The subsprite health goes from 40 to 100, in steps of 20.
-    push    { r1 }
+    mov     r5, r1
     mov     r4, r0
     mov     r0, r2
     mov     r1, #20
-    bl DivideUnsigned
+    bl      DivideUnsigned
     mov     r1, #5
     sub     r0, r1, r0
     ldr     r1, =ZazabiLookupTable
     ldrb    r0, [r1, r0]
-    pop     { r1 }      ; restore r1 to point to work3
-    cmp     r0, #@ZazabiMagicNumber
+    mov     r1, r5      ; restore r1 to point to work3
+    cmp     r0, #@ZazabiDefaultAdjustmentNumber
     bne     @@ApplyOffsets
     mov     r0, r4      ; If offset was magic number, restore the original random number
 
@@ -74,7 +74,7 @@ ZazabiLookupTable:
     mov     r1, r0      ; temp store the random value in r1
     ldr     r0, =ZazabiLookupTable
     ldrb    r0, [r0, #3]
-    cmp     r0, @ZazabiMagicNumber
+    cmp     r0, @ZazabiDefaultAdjustmentNumber
     bne     @@Exit
     mov     r0, r1      ; offset was magic number, so restore it back to random number
 

--- a/src/main.s
+++ b/src/main.s
@@ -72,6 +72,7 @@ reserve_pointer DefaultStereoFlagPointer
 reserve_pointer InstantMorphFlagPointer
 reserve_pointer ForceExcessHealthDisplayPointer
 reserve_pointer GadoraTablePointer
+reserve_pointer ZazabiTablePointer
 
 
 ; Mark end-of-file padding as free space
@@ -166,6 +167,7 @@ DataFreeSpaceEnd equ DataFreeSpace + DataFreeSpaceLen
 .notice "Applying consistency patches..."
 .include "src/consistency/animals.s"
 .include "src/consistency/gadora.s"
+.include "src/consistency/zazabi.s"
 
 .if !DEBUG
 .include "src/nonlinear/item-select.s"


### PR DESCRIPTION
Stacked PR because i'm too lazy to resolve merge conflcits in changelog and main.s

```
; Removes relevant RNG of Zazabi:
; Each phase can have its own number assigned by the patcher on how much to offset the base result by. 
; For phase 1 to 3, this number denotes how many additional jumps Zazabi does where it cannot be hit.
; Thus the calculation on how many extra jumps to do ends up as: (CurrentPhase-1) + ProvidedNumber
; For phase 4, the number denotes how many additional frames to crawl more. The final calculation ends up as: 60 + ProvidedNumber
```

Tested out following combinations:
- First phase 0xFF
- First phase 0xA
- First phase 0x0
- Second phase 0xFF
- Second phase 0x1
- Last phase 0xFF
- Last phase 0x0

And all worked as expected.

Part of #134 