### PR TITLE
Remove RNG from yakuza

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Changed: Added an option to change how many times each Gadora shoots before being vulnerable. If not provided, it will fall back to vanilla behaviour.
 - Changed: Added an option to tweak each Gadora how often it shoots projectiles before being vulnerable. If not provided, it will fall back to vanilla behaviour.
 - Changed: Added an option to adjust how many additional jumps Zazabi does in rounds 1 to 3, and how long it crawls for in round 4. If not provided, it will fall back to vanilla behaviour.
+- Changed: Added an option to adjust how many rounds Yakuza will additionally do before it opens its mouth again.
 
 ## 0.12.3 - 2026-06-16
 - Fixed: Offworld item graphics no longer appear as an Empty Tank

--- a/src/consistency/yakuza.s
+++ b/src/consistency/yakuza.s
@@ -38,7 +38,7 @@ YakuzaRounds:
     ldr     r1, =CurrentSprite
     add     r1, Sprite_Work0
     strb    r0, [r1, #0]
-    bl      0805C520h   ; end of the function where it tries to return
+    bl      0805C520h   ; end of the function where it prepares for returning
 .pool
 .endfunc
 .endautoregion

--- a/src/consistency/yakuza.s
+++ b/src/consistency/yakuza.s
@@ -1,0 +1,44 @@
+; Removes relevant RNG of Yakuza, by letting the patcher write a number on how many rounds Yakuza will additionally
+; do in its first phase. Thus the final calculation ends up being: 1 + ProvidedNumber
+
+
+; In YakuzaClosingMouth, hijack where it tries to adjust work0 on how many rounds to do
+.org 0805C51Ah
+.area 0xC
+    bl @YakuzaClosingMouthHijack
+.endarea
+
+
+@YakuzaMagicNumber equ 0FFh
+
+.org YakuzaRoundsPointer
+.area 04h
+    .dw     YakuzaRounds
+.endarea
+
+.autoregion
+.align 2
+YakuzaRounds:
+.db @YakuzaMagicNumber
+
+.align 2
+.func @YakuzaClosingMouthHijack
+; r0 is the value of work0 (after doing gSpriteRandomNumber/4)
+; r1 at the end of the function has to point to work0
+
+    mov     r1, r0  ; temp store the random number
+    ldr     r0, =YakuzaRounds
+    ldrb    r0, [r0, #0]
+    cmp     r0, @YakuzaMagicNumber
+    bne     @@ApplyOffset
+    mov     r0, r1  ; get the random number back
+
+@@ApplyOffset:
+    add     r0, #1  ; Vanilla functionality of having 1 round at minumum
+    ldr     r1, =CurrentSprite
+    add     r1, Sprite_Work0
+    strb    r0, [r1, #0]
+    bl      0805C520h   ; end of the function where it tries to return
+.pool
+.endfunc
+.endautoregion

--- a/src/main.s
+++ b/src/main.s
@@ -73,6 +73,7 @@ reserve_pointer InstantMorphFlagPointer
 reserve_pointer ForceExcessHealthDisplayPointer
 reserve_pointer GadoraTablePointer
 reserve_pointer ZazabiTablePointer
+reserve_pointer YakuzaRoundsPointer
 
 
 ; Mark end-of-file padding as free space
@@ -168,6 +169,7 @@ DataFreeSpaceEnd equ DataFreeSpace + DataFreeSpaceLen
 .include "src/consistency/animals.s"
 .include "src/consistency/gadora.s"
 .include "src/consistency/zazabi.s"
+.include "src/consistency/yakuza.s"
 
 .if !DEBUG
 .include "src/nonlinear/item-select.s"


### PR DESCRIPTION
Stacked PR for the same reason as the previous one


```
; Removes relevant RNG of Yakuza, by letting the patcher write a number on how many rounds Yakuza will additionally
; do in its first phase. Thus the final calculation ends up being: 1 + ProvidedNumber
```

Tested this with the number being 0xFF and 0x0

Assuming all the other PRs are merged too, this would fix #134 (minus arachnus, but iirc we agreed to let arachnus keep being as is for now)